### PR TITLE
Add `jupyter-server-ai-tools` as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "jupyterlab-eventlistener"
+    "jupyterlab-eventlistener",
+    "jupyter-server-ai-tools>=0.2.0,<0.3",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
Since it's used here:

https://github.com/jupyter-ai-contrib/jupyterlab-commands-toolkit/blob/50942e0049f585fafad0f48746339b28a3a1b5bc/jupyterlab_commands_toolkit/tools.py#L3

Although the actual don't seem to be used withing this code base? So maybe they were exposed so they could be used from another package?

In the meantime maybe it could still be worth adding `jupyter-server-ai-tools` as a dependency?
